### PR TITLE
Integration tests: assert against own repo

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -11,13 +11,13 @@ fn gets_pull_requets_by_user() {
     // Should always contain test PR for Goodbrother.
     let goodbrother_prs: Vec<&PullRequest> = result
         .iter()
-        .filter(|pr| pr.repository.eq("stscoundrel/goodbrother"))
+        .filter(|pr| pr.repository.eq("stscoundrel/goodbrother-rust"))
         .collect();
 
     assert!(goodbrother_prs.len() > 0);
 
     assert!(goodbrother_prs[0].name.eq("Fixture PR for integration tests"));
-    assert!(goodbrother_prs[0].link.eq("https://github.com/stscoundrel/goodbrother/pull/18"));
+    assert!(goodbrother_prs[0].link.eq("https://github.com/stscoundrel/goodbrother-rust/pull/16"));
     assert_eq!(goodbrother_prs[0].is_dependabot, false);
 }
 
@@ -31,13 +31,13 @@ fn gets_grouped_pull_requests_by_user() {
     // Should always contain prs for Goodbrother
     let goodbrother_prs: Vec<&Repository> = result
         .iter()
-        .filter(|repo| repo.name.eq("stscoundrel/goodbrother"))
+        .filter(|repo| repo.name.eq("stscoundrel/goodbrother-rust"))
         .collect();
 
     assert!(goodbrother_prs.len() > 0);
 
-    assert!(goodbrother_prs[0].name.eq("stscoundrel/goodbrother"));
+    assert!(goodbrother_prs[0].name.eq("stscoundrel/goodbrother-rust"));
     assert!(goodbrother_prs[0].pull_requests[0].name.eq("Fixture PR for integration tests"));
-    assert!(goodbrother_prs[0].pull_requests[0].link.eq("https://github.com/stscoundrel/goodbrother/pull/18"));
+    assert!(goodbrother_prs[0].pull_requests[0].link.eq("https://github.com/stscoundrel/goodbrother-rust/pull/16"));
     assert_eq!(goodbrother_prs[0].pull_requests[0].is_dependabot, false);
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -16,9 +16,9 @@ fn gets_pull_requets_by_user() {
 
     assert!(goodbrother_prs.len() > 0);
 
-    assert!(goodbrother_prs[0].name.eq("Fixture PR for integration tests"));
-    assert!(goodbrother_prs[0].link.eq("https://github.com/stscoundrel/goodbrother-rust/pull/16"));
-    assert_eq!(goodbrother_prs[0].is_dependabot, false);
+    assert!(goodbrother_prs.last().unwrap().name.eq("Fixture PR for integration tests"));
+    assert!(goodbrother_prs.last().unwrap().link.eq("https://github.com/stscoundrel/goodbrother-rust/pull/16"));
+    assert_eq!(goodbrother_prs.last().unwrap().is_dependabot, false);
 }
 
 #[test]
@@ -37,7 +37,7 @@ fn gets_grouped_pull_requests_by_user() {
     assert!(goodbrother_prs.len() > 0);
 
     assert!(goodbrother_prs[0].name.eq("stscoundrel/goodbrother-rust"));
-    assert!(goodbrother_prs[0].pull_requests[0].name.eq("Fixture PR for integration tests"));
-    assert!(goodbrother_prs[0].pull_requests[0].link.eq("https://github.com/stscoundrel/goodbrother-rust/pull/16"));
-    assert_eq!(goodbrother_prs[0].pull_requests[0].is_dependabot, false);
+    assert!(goodbrother_prs[0].pull_requests.last().unwrap().name.eq("Fixture PR for integration tests"));
+    assert!(goodbrother_prs[0].pull_requests.last().unwrap().link.eq("https://github.com/stscoundrel/goodbrother-rust/pull/16"));
+    assert_eq!(goodbrother_prs[0].pull_requests.last().unwrap().is_dependabot, false);
 }


### PR DESCRIPTION
Previously tested against fixture PR in TypeScript version repo. No need to have dependency to external repo.

Fixes #15